### PR TITLE
[Chore] Cache aq nodes

### DIFF
--- a/public/json/nodes.json
+++ b/public/json/nodes.json
@@ -1,0 +1,6 @@
+{
+  "count": 0,
+  "next": null,
+  "previous": null,
+  "results": []
+}

--- a/src/lib/aq.js
+++ b/src/lib/aq.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+const CACHE_FILENAME = 'nodes.json';
+
+const headers = new Headers();
+headers.append('Authorization', `token ${process.env.KE_HAP}`);
+
+async function fetchAllNodes(url, options = { headers }, times = 0) {
+  const response = await fetch(url, options);
+  const resjson = await response.json();
+  const data = resjson.results;
+  if (resjson.next) {
+    const nextData = await fetchAllNodes(resjson.next, options, times + 1);
+    return { ...nextData, results: data.concat(nextData.results) };
+  }
+
+  return { ...resjson, results: data };
+}
+
+async function fetchNodes(days = 7) {
+  const toDate = new Date();
+  const fromDate = toDate.setDate(toDate.getDate() - days);
+  const lastNotify = new Date(fromDate).toISOString();
+
+  return fetchAllNodes(
+    `https://api.sensors.africa/v1/node?last_notify__gte=${lastNotify}`
+  );
+}
+
+export async function loadNodes() {
+  const nodes = await fetchNodes();
+  const publicDirectory = path.join(process.cwd(), 'public/json');
+  const filePath = path.join(publicDirectory, CACHE_FILENAME);
+  fs.writeFileSync(filePath, JSON.stringify(nodes), 'utf8');
+  return nodes;
+}
+
+export async function getNodes() {
+  let cachedNodes;
+  try {
+    const publicDirectory = path.join(process.cwd(), 'public/json');
+    const filePath = path.join(publicDirectory, CACHE_FILENAME);
+    cachedNodes = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    cachedNodes = null;
+  }
+
+  return cachedNodes;
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Hero from 'components/Landing/Hero';
 import { providers, useSession } from 'next-auth/client';
 import Router from 'next/router';
+import { loadNodes } from 'lib/aq';
 
 function Home(props) {
   const [session] = useSession();
@@ -16,7 +17,14 @@ function Home(props) {
 }
 
 export async function getStaticProps(context) {
-  return { props: { providers: await providers(context) } };
+  const nodes = await loadNodes();
+  return {
+    props: {
+      providers: await providers(context),
+      nodes: nodes?.length ?? null,
+    },
+    revalidate: 60 * 60, // 60 minutes
+  };
 }
 
 export default Home;


### PR DESCRIPTION
## Description

This PR _tries_, I repeat, _tries_ to cache nodes in `public/json/nodes.json` file so as to reduce number of calls made to the live sensors.AFRICA API.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
