### PR TITLE
[HotFix] Use cached nodes in the api

### DIFF
--- a/src/pages/api/nodes.js
+++ b/src/pages/api/nodes.js
@@ -1,16 +1,9 @@
-import { fetchAllNodes } from 'api';
+import { getNodes } from 'lib/aq';
 
 export default async function handler(req, res) {
-  const daysAgo = req.query.days || 7;
-  const date = new Date();
-  const fromDate = date.setDate(date.getDate() - daysAgo);
-  const lastNotify = new Date(fromDate).toISOString();
-  try {
-    const data = await fetchAllNodes(
-      `https://api.sensors.africa/v1/node?last_notify__gte=${lastNotify}`
-    );
+  const data = await getNodes();
+  if (data) {
     return res.status(200).json(data);
-  } catch (err) {
-    return res.status(500).json(err);
   }
+  return res.status(500).json();
 }


### PR DESCRIPTION
## Description

/api/nodes was still making call to the live sensors.AFRICA api. This PR switches to using the cached nodes data created in #15 .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas